### PR TITLE
Fixes capitalization for linux

### DIFF
--- a/io_scene_angelstudios/import_bms.py
+++ b/io_scene_angelstudios/import_bms.py
@@ -26,7 +26,7 @@ def vert_key(position, normal=None):
 ######################################################
 # IMPORT
 ######################################################
-def import_bms_object(filepath):
+def import_bms_object(filepath, texture_basepath):
     scn = bpy.context.scene
 
     points = []
@@ -112,7 +112,9 @@ def import_bms_object(filepath):
             if os.path.basename(asset_root_path).upper() == "BMS": # one more, we're in a BMS dir
                 asset_root_path = os.path.abspath(os.path.join(os.path.dirname(filepath), "..", ".."))
             asset_base_path = os.path.abspath(os.path.dirname(filepath))
-            texture = utils.try_load_dds_texture(texture_name, (os.path.join(asset_root_path, "TEX16O"), os.path.join(asset_root_path, "TEX16A"), asset_base_path))
+            try_paths = (os.path.join(asset_root_path, "TEX16O"), os.path.join(asset_root_path, "TEX16A"), asset_base_path)
+            try_extensions = (".dds")
+            texture = utils.try_load_texture(try_paths, texture_name, try_extensions)
 
             mat = create_material(texture_name)
             mat_wrap = node_shader_utils.PrincipledBSDFWrapper(mat, is_readonly=False) 

--- a/io_scene_angelstudios/import_bms.py
+++ b/io_scene_angelstudios/import_bms.py
@@ -26,7 +26,7 @@ def vert_key(position, normal=None):
 ######################################################
 # IMPORT
 ######################################################
-def import_bms_object(filepath, texture_basepath):
+def import_bms_object(filepath):
     scn = bpy.context.scene
 
     points = []
@@ -113,7 +113,7 @@ def import_bms_object(filepath, texture_basepath):
                 asset_root_path = os.path.abspath(os.path.join(os.path.dirname(filepath), "..", ".."))
             asset_base_path = os.path.abspath(os.path.dirname(filepath))
             try_paths = (os.path.join(asset_root_path, "TEX16O"), os.path.join(asset_root_path, "TEX16A"), asset_base_path)
-            try_extensions = (".dds")
+            try_extensions = (".dds", ".bmp", ".png")
             texture = utils.try_load_texture(try_paths, texture_name, try_extensions)
 
             mat = create_material(texture_name)

--- a/io_scene_angelstudios/import_mod.py
+++ b/io_scene_angelstudios/import_mod.py
@@ -593,7 +593,17 @@ def import_mod_object_bin(filepath, texture_basepath):
 def import_mod_object(filepath, texture_basepath):
     with open(filepath, 'rb') as file:
         if not texture_basepath:
-            texture_basepath = os.path.join(os.path.abspath(os.path.join(os.path.dirname(filepath), "..")), "texture")
+            search_path = os.path.dirname(filepath)
+            texture_basepath = os.path.join(os.path.abspath(os.path.join(search_path, "..")), "texture_x")
+            for _ in range(4):
+                search_path = os.path.dirname(search_path)
+                for entry in os.listdir(search_path):
+                    entry_path = os.path.join(search_path, entry)
+                    if os.path.isdir(entry_path) and entry.lower().startswith("texture"):
+                        texture_basepath = entry_path
+                        break
+
+            print("Textures path: " + texture_basepath)
 
         # determine version and read accordingly
         version = file.read(13)

--- a/io_scene_angelstudios/import_mod.py
+++ b/io_scene_angelstudios/import_mod.py
@@ -219,7 +219,7 @@ def import_mod_object_ascii(filepath):
             mat_wrap.roughness = (1.0 - shininess)
             
             if len(mat_textures) > 0:
-                texture_name = mat_textures[0]
+                texture_name = mat_textures[0].lower()
                 asset_root_path = os.path.abspath(os.path.join(os.path.dirname(filepath), ".."))
                 asset_base_path = os.path.abspath(os.path.dirname(filepath))
                 texture = utils.try_load_texture(texture_name, (os.path.join(asset_root_path, "texture_x"), os.path.join(asset_root_path, "texture"), asset_base_path))
@@ -512,7 +512,7 @@ def import_mod_object_bin(filepath):
             mat_wrap.roughness = (1.0 - shininess)
             
             if len(mat_textures) > 0:
-                texture_name = mat_textures[0]
+                texture_name = mat_textures[0].lower()
                 asset_root_path = os.path.abspath(os.path.join(os.path.dirname(filepath), ".."))
                 asset_base_path = os.path.abspath(os.path.dirname(filepath))
                 texture = utils.try_load_texture(texture_name, (os.path.join(asset_root_path, "texture_x"), os.path.join(asset_root_path, "texture"), asset_base_path))

--- a/io_scene_angelstudios/import_mod.py
+++ b/io_scene_angelstudios/import_mod.py
@@ -512,7 +512,7 @@ def import_mod_object_bin(filepath):
             mat_wrap.roughness = (1.0 - shininess)
             
             if len(mat_textures) > 0:
-                texture_name = mat_textures[0].lower()
+                texture_name = mat_textures[0]
                 asset_root_path = os.path.abspath(os.path.join(os.path.dirname(filepath), ".."))
                 asset_base_path = os.path.abspath(os.path.dirname(filepath))
                 texture = utils.try_load_texture(texture_name, (os.path.join(asset_root_path, "texture_x"), os.path.join(asset_root_path, "texture"), asset_base_path))

--- a/io_scene_angelstudios/import_mod.py
+++ b/io_scene_angelstudios/import_mod.py
@@ -592,6 +592,9 @@ def import_mod_object_bin(filepath, texture_basepath):
 
 def import_mod_object(filepath, texture_basepath):
     with open(filepath, 'rb') as file:
+        if not texture_basepath:
+            texture_basepath = os.path.join(os.path.abspath(os.path.join(os.path.dirname(filepath), "..")), "texture")
+
         # determine version and read accordingly
         version = file.read(13)
         if version == b"version: 1.06" or version == b"version: 1.09" or version == b"version: 1.10":

--- a/io_scene_angelstudios/import_mod.py
+++ b/io_scene_angelstudios/import_mod.py
@@ -80,7 +80,7 @@ def add_vertex_groups(ob, bone_map):
 ######################################################
 # IMPORT MAIN FILES
 ######################################################
-def import_mod_object_ascii(filepath, texture_basepath):
+def import_mod_object_ascii(filepath, textures_basepath):
     with open(filepath, 'r') as file:   
         scn = bpy.context.scene
         # add a mesh and link it to the scene
@@ -221,7 +221,7 @@ def import_mod_object_ascii(filepath, texture_basepath):
             if len(mat_textures) > 0:
                 texture_name = mat_textures[0]
                 asset_base_path = os.path.abspath(os.path.dirname(filepath))
-                try_paths = (texture_basepath, asset_base_path)
+                try_paths = (textures_basepath, asset_base_path)
                 try_extensions = (".tex", ".xtex", ".tga", ".bmp", ".png")
                 texture = utils.try_load_texture(try_paths, texture_name, try_extensions)
                 mat_wrap.base_color_texture.image = texture
@@ -356,7 +356,7 @@ def import_mod_object_ascii(filepath, texture_basepath):
         # return the added object
         return ob
 
-def import_mod_object_bin(filepath, texture_basepath):
+def import_mod_object_bin(filepath, textures_basepath):
     with open(filepath, 'rb') as file:
         scn = bpy.context.scene
         # add a mesh and link it to the scene
@@ -516,7 +516,7 @@ def import_mod_object_bin(filepath, texture_basepath):
                 texture_name = mat_textures[0]
                 asset_root_path = os.path.abspath(os.path.join(os.path.dirname(filepath), ".."))
                 asset_base_path = os.path.abspath(os.path.dirname(filepath))
-                try_paths = (texture_basepath, asset_base_path)
+                try_paths = (textures_basepath, asset_base_path)
                 try_extensions = (".tex", ".xtex", ".tga", ".bmp", ".png")
                 texture = utils.try_load_texture(try_paths, texture_name, try_extensions)
                 mat_wrap.base_color_texture.image = texture
@@ -590,27 +590,28 @@ def import_mod_object_bin(filepath, texture_basepath):
 
         return ob
 
-def import_mod_object(filepath, texture_basepath):
+def import_mod_object(filepath, textures_basepath):
     with open(filepath, 'rb') as file:
-        if not texture_basepath:
+        if not textures_basepath:
             search_path = os.path.dirname(filepath)
-            texture_basepath = os.path.join(os.path.abspath(os.path.join(search_path, "..")), "texture_x")
             for _ in range(4):
                 search_path = os.path.dirname(search_path)
                 for entry in os.listdir(search_path):
                     entry_path = os.path.join(search_path, entry)
                     if os.path.isdir(entry_path) and entry.lower().startswith("texture"):
-                        texture_basepath = entry_path
+                        textures_basepath = entry_path
                         break
+                if textures_basepath:
+                    break
 
-            print("Textures path: " + texture_basepath)
+            print("Textures path: " + textures_basepath)
 
         # determine version and read accordingly
         version = file.read(13)
         if version == b"version: 1.06" or version == b"version: 1.09" or version == b"version: 1.10":
-            return import_mod_object_ascii(filepath, texture_basepath)
+            return import_mod_object_ascii(filepath, textures_basepath)
         elif version == b"version: 2.00" or version == b"version: 2.10" or version == b"version: 2.12":
-            return import_mod_object_bin(filepath, texture_basepath)
+            return import_mod_object_bin(filepath, textures_basepath)
         else:
             raise Exception("BAD MOD VERSION: " + str(version))
     
@@ -621,12 +622,12 @@ def import_mod_object(filepath, texture_basepath):
 def load(operator,
          context,
          filepath="",
-         texture_basepath="",
+         textures_basepath="",
          ):
 
     print("importing MOD: %r..." % (filepath))
     time1 = time.perf_counter()
-    import_mod_object(filepath, texture_basepath)
+    import_mod_object(filepath, textures_basepath)
     print(" done in %.4f sec." % (time.perf_counter() - time1))
     
     return {'FINISHED'}

--- a/io_scene_angelstudios/import_modscene.py
+++ b/io_scene_angelstudios/import_modscene.py
@@ -34,8 +34,7 @@ class ImportMODSceneOperator(bpy.types.Operator):
             # import models
             scene_prefix = f"{self.scene_name}_"
 
-            matrix_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "geometry")
-
+            matrix_basepath = self.directory
             search_path = self.directory
             for _ in range(4):
                 search_path = os.path.dirname(search_path)
@@ -44,8 +43,7 @@ class ImportMODSceneOperator(bpy.types.Operator):
                     matrix_basepath = geometry_path
                     break
 
-            textures_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "texture_x")
-
+            textures_basepath = self.directory
             search_path = self.directory
             for _ in range(4):
                 search_path = os.path.dirname(search_path)

--- a/io_scene_angelstudios/import_modscene.py
+++ b/io_scene_angelstudios/import_modscene.py
@@ -34,7 +34,8 @@ class ImportMODSceneOperator(bpy.types.Operator):
             # import models
             scene_prefix = f"{self.scene_name}_"
 
-            matrix_basepath = self.directory
+            matrix_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "geometry")
+
             search_path = self.directory
             for _ in range(4):
                 search_path = os.path.dirname(search_path)
@@ -43,7 +44,8 @@ class ImportMODSceneOperator(bpy.types.Operator):
                     matrix_basepath = geometry_path
                     break
 
-            textures_basepath = self.directory
+            textures_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "texture_x")
+
             search_path = self.directory
             for _ in range(4):
                 search_path = os.path.dirname(search_path)
@@ -52,8 +54,6 @@ class ImportMODSceneOperator(bpy.types.Operator):
                     if os.path.isdir(entry_path) and entry.lower().startswith("texture"):
                         textures_basepath = entry_path
                         break
-                if textures_basepath:
-                    break
 
             print("Textures path: " + textures_basepath)
 

--- a/io_scene_angelstudios/import_modscene.py
+++ b/io_scene_angelstudios/import_modscene.py
@@ -34,25 +34,28 @@ class ImportMODSceneOperator(bpy.types.Operator):
             # import models
             scene_prefix = f"{self.scene_name}_"
 
-            matrix_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "geometry") # Dis-gusting. Temporary.
+            matrix_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "geometry")
 
-            assets_basepath = self.directory
+            search_path = self.directory
             for _ in range(4):
-                assets_basepath = os.path.dirname(assets_basepath)
-                geometry_path = os.path.join(assets_basepath, "geometry")
+                search_path = os.path.dirname(search_path)
+                geometry_path = os.path.join(search_path, "geometry")
                 if os.path.exists(geometry_path):
                     matrix_basepath = geometry_path
                     break
 
             texture_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "texture_x")
-            assets_basepath = self.directory
+
+            search_path = self.directory
             for _ in range(4):
-                for name in ("texture", "texture_x"):
-                    assets_basepath = os.path.dirname(assets_basepath)
-                    texture_path = os.path.join(assets_basepath, name)
-                    if os.path.exists(texture_path):
-                        texture_basepath = texture_path
+                search_path = os.path.dirname(search_path)
+                for entry in os.listdir(search_path):
+                    entry_path = os.path.join(search_path, entry)
+                    if os.path.isdir(entry_path) and entry.lower().startswith("texture"):
+                        texture_basepath = entry_path
                         break
+
+            print("Textures path: " + texture_basepath)
 
             for file in os.listdir(self.directory):
                 file_l = file.lower()

--- a/io_scene_angelstudios/import_modscene.py
+++ b/io_scene_angelstudios/import_modscene.py
@@ -34,8 +34,7 @@ class ImportMODSceneOperator(bpy.types.Operator):
             # import models
             scene_prefix = f"{self.scene_name}_"
 
-            matrix_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "geometry")
-
+            matrix_basepath = self.directory
             search_path = self.directory
             for _ in range(4):
                 search_path = os.path.dirname(search_path)
@@ -44,25 +43,26 @@ class ImportMODSceneOperator(bpy.types.Operator):
                     matrix_basepath = geometry_path
                     break
 
-            texture_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "texture_x")
-
+            textures_basepath = self.directory
             search_path = self.directory
             for _ in range(4):
                 search_path = os.path.dirname(search_path)
                 for entry in os.listdir(search_path):
                     entry_path = os.path.join(search_path, entry)
                     if os.path.isdir(entry_path) and entry.lower().startswith("texture"):
-                        texture_basepath = entry_path
+                        textures_basepath = entry_path
                         break
+                if textures_basepath:
+                    break
 
-            print("Textures path: " + texture_basepath)
+            print("Textures path: " + textures_basepath)
 
             for file in os.listdir(self.directory):
                 file_l = file.lower()
                 if file_l.startswith(scene_prefix) and (file_l.endswith(".mod") or file_l.endswith(".xmod")):
                     print("IMPORTING " + file_l)
                     file_noext = os.path.splitext(file)[0]
-                    imported_ob = import_mod.import_mod_object(filepath=os.path.join(self.directory, file), texture_basepath = texture_basepath)
+                    imported_ob = import_mod.import_mod_object(filepath=os.path.join(self.directory, file), textures_basepath = textures_basepath)
                     imported_ob.name = file_noext[len(scene_prefix):]
                     imported_ob_basename = utils.object_basename(file_noext)
                     if os.path.exists(os.path.join(matrix_basepath, f"{imported_ob_basename}.mtx")):

--- a/io_scene_angelstudios/import_modscene.py
+++ b/io_scene_angelstudios/import_modscene.py
@@ -33,13 +33,33 @@ class ImportMODSceneOperator(bpy.types.Operator):
             
             # import models
             scene_prefix = f"{self.scene_name}_"
+
             matrix_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "geometry") # Dis-gusting. Temporary.
+
+            assets_basepath = self.directory
+            for _ in range(4):
+                assets_basepath = os.path.dirname(assets_basepath)
+                geometry_path = os.path.join(assets_basepath, "geometry")
+                if os.path.exists(geometry_path):
+                    matrix_basepath = geometry_path
+                    break
+
+            texture_basepath = os.path.join(os.path.abspath(os.path.join(self.directory, "..")), "texture_x")
+            assets_basepath = self.directory
+            for _ in range(4):
+                for name in ("texture", "texture_x"):
+                    assets_basepath = os.path.dirname(assets_basepath)
+                    texture_path = os.path.join(assets_basepath, name)
+                    if os.path.exists(texture_path):
+                        texture_basepath = texture_path
+                        break
+
             for file in os.listdir(self.directory):
                 file_l = file.lower()
                 if file_l.startswith(scene_prefix) and (file_l.endswith(".mod") or file_l.endswith(".xmod")):
                     print("IMPORTING " + file_l)
                     file_noext = os.path.splitext(file)[0]
-                    imported_ob = import_mod.import_mod_object(filepath=os.path.join(self.directory, file))
+                    imported_ob = import_mod.import_mod_object(filepath=os.path.join(self.directory, file), texture_basepath = texture_basepath)
                     imported_ob.name = file_noext[len(scene_prefix):]
                     imported_ob_basename = utils.object_basename(file_noext)
                     if os.path.exists(os.path.join(matrix_basepath, f"{imported_ob_basename}.mtx")):

--- a/io_scene_angelstudios/utils.py
+++ b/io_scene_angelstudios/utils.py
@@ -189,7 +189,7 @@ def _image_load_placeholder(name, path):
     image.filepath_raw = path
     return image
         
-def try_load_texture(tex_name, search_paths):
+def try_load_texture(search_paths, tex_name, extensions):
     existing_image = bpy.data.images.get(tex_name)
     if existing_image is not None:
         return existing_image
@@ -197,42 +197,19 @@ def try_load_texture(tex_name, search_paths):
     bl_img = None
     for search_path in search_paths:
         if os.path.isdir(search_path):
-            check_file = os.path.join(search_path, tex_name + ".tex")
-            if os.path.exists(check_file):
-                bl_img = _load_texture_from_path(check_file)
-
-            if bl_img is None:
-                check_file = os.path.join(search_path, tex_name + ".xtex")
-                if os.path.exists(check_file):
-                    bl_img = _load_texture_from_path(check_file)
-
-            if bl_img is None:
-                standard_extensions = (".tga", ".bmp", ".png")
-                for ext in standard_extensions:
-                    check_file = os.path.join(search_path, tex_name + ext)
-                    if os.path.exists(check_file):
-                        bl_img = _load_texture_from_path(check_file)
-                        if bl_img is not None:
+            entries = os.listdir(search_path)
+            for ext in extensions:
+                for entry in entries:
+                    entry_path = os.path.join(search_path, entry)
+                    if os.path.isfile(entry_path):
+                        check_file = tex_name + ext
+                        if check_file.lower() in entry.lower():
+                            bl_img = _load_texture_from_path(entry_path)
                             break
 
-            if bl_img is not None:
-                break
+                if bl_img is not None:
+                    break
 
-    if bl_img is None:
-        bl_img = _image_load_placeholder(tex_name, os.path.join(search_path, tex_name))
-    return bl_img
-
-def try_load_dds_texture(tex_name, search_paths):
-    existing_image = bpy.data.images.get(tex_name)
-    if existing_image is not None:
-        return existing_image
-    
-    bl_img = None
-    for search_path in search_paths:
-        if os.path.isdir(search_path):
-            check_file = os.path.join(search_path, tex_name + ".dds")
-            if os.path.exists(check_file):
-                bl_img = _load_texture_from_path(check_file)
             if bl_img is not None:
                 break
 

--- a/io_scene_angelstudios/utils.py
+++ b/io_scene_angelstudios/utils.py
@@ -204,6 +204,7 @@ def try_load_texture(search_paths, tex_name, extensions):
                     if os.path.isfile(entry_path):
                         check_file = tex_name + ext
                         if check_file.lower() in entry.lower():
+                            print("Texture: " + entry)
                             bl_img = _load_texture_from_path(entry_path)
                             break
 
@@ -214,6 +215,7 @@ def try_load_texture(search_paths, tex_name, extensions):
                 break
 
     if bl_img is None:
+        print("Texture " + tex_name + " is missing!")
         bl_img = _image_load_placeholder(tex_name, os.path.join(search_path, tex_name))
     return bl_img
    


### PR DESCRIPTION
Fix capital letters in texture names.

Example material in vp_m5_pnl_hd_udmg_m.xmod
```
mtl vp_M5:hood {
        packets:        2
        primitives:     60
        textures:       1
        illum: diffuse
        ambient:        0.000000 0.000000 0.000000
        diffuse:        0.588000 0.588000 0.588000
        specular:       0.900000 0.900000 0.900000
        texture: 0 "vp_M5_hood"
        attributes:     1
        float shininess:        0.800000
}
```
From texture_x folder list of available files:
- vp_m5_hood-a.tex 
- vp_m5_hood-b.tex
- vp_m5_hood-c.tex
- vp_m5_hood-d.tex
- vp_m5_hood.tex

Texture file vp_M5_hood.tex will not be found for Linux since it is case sensitive to filenames.